### PR TITLE
Fix wrong validator name in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Determine if the field under validation is a valid ISO3166 country code.
 public function rules()
 {
     return [
-        'country' => ['required', new Country()],
+        'country' => ['required', new CountryCode()],
     ];
 }
 ```
@@ -81,7 +81,7 @@ If you want to validate a nullable country code field, you can call the `nullabl
 public function rules()
 {
     return [
-        'country' => [(new Country())->nullable()],
+        'country' => [(new CountryCode())->nullable()],
     ];
 }
 ```


### PR DESCRIPTION
The readme contains examples for using the `CountryCode` validator, but they use the `Country` class name, which is incorrect. This PR fixes the name to use the right `CountryCode` name.